### PR TITLE
Include Packing file to fix hooks

### DIFF
--- a/montapacking-checkout.php
+++ b/montapacking-checkout.php
@@ -22,6 +22,7 @@
 use Monta\Packing;
 
 include('montapacking-config.php');
+include("src/Packing.php"); // Still required because core does not read PSR-4 when adding hooks
 
 if (esc_attr(get_option('monta_logerrors'))) {
     define('WC_LOG_HANDLER', 'WC_Log_Handler_DB');


### PR DESCRIPTION
WooCommerce core does not recognize autoloaded files when adding filter hooks